### PR TITLE
*.swp && fixes cabal install && template-haskell v2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cabal-dev
 *.chi
 *.chs.h
 *~
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: haskell
 
+ghc: 7.8
+
 branches:
   except:
     - library

--- a/LazySmallCheck2012.cabal
+++ b/LazySmallCheck2012.cabal
@@ -32,7 +32,7 @@ Library
                        Test.LazySmallCheck2012.Stats
   Build-depends:       base >=4 && < 5, deepseq >= 1.2 && < 2,
                        ghc >= 7 && < 8, syb >= 0.2 && < 0.5,
-                       template-haskell >= 2.5 && < 3, 
+                       template-haskell >= 2.9 && < 3,
                        uniplate >= 1.3 && < 2
 
 Test-Suite functionality 

--- a/LazySmallCheck2012.cabal
+++ b/LazySmallCheck2012.cabal
@@ -28,7 +28,8 @@ Library
                        Test.LazySmallCheck2012.Core, 
                        Test.LazySmallCheck2012.FunctionalValues, 
                        Test.LazySmallCheck2012.FunctionalValues.Instances,
-                       Test.LazySmallCheck2012.TH
+                       Test.LazySmallCheck2012.TH,
+                       Test.LazySmallCheck2012.Stats
   Build-depends:       base >=4 && < 5, deepseq >= 1.2 && < 2,
                        ghc >= 7 && < 8, syb >= 0.2 && < 0.5,
                        template-haskell >= 2.5 && < 3, 

--- a/Test/LazySmallCheck2012/TH.hs
+++ b/Test/LazySmallCheck2012/TH.hs
@@ -75,10 +75,12 @@ deriveArgument tname = do
   let unitT = [t| () |]
   let sumT t0 t1 = [t| Either $(t0) $(t1) |]
   let proT t0 t1 = [t| ($(t0), $(t1)) |]
-  let instBase (TySynInstD base _ _) = tySynInstD base [tfullname]
-         (foldr sumT unitT 
-          [ foldr proT unitT [ [t| BaseCast $(return t) |] | t <- ts ]
-          | (c, ts) <- tconstrs' ])
+  let instBase (TySynInstD base (TySynEqn _ _)) =
+        tySynInstD base
+          (tySynEqn [tfullname]
+            (foldr sumT unitT
+             [ foldr proT unitT [ [t| BaseCast $(return t) |] | t <- ts ]
+             | (c, ts) <- tconstrs' ]))
       instBase x = return x
   -- Change instance for toBase
   let proE x y = [| ($x, $y) |]


### PR DESCRIPTION
This pull request introduces 3 unrelated changes:
- `*.swp` on `.gitignore`.
- Fixes an error when installing with `cabal install`.
  - The `Stats` module was not exposed, that made any package using LSC crash with strange link errors.
- Fixes compilatios errors on template-haskell v2.9:
  - They introduced a change in `TySynInstD` constructors.
  - I could have used `if impl(template-haskell < v2.9) ... cpp-flags: LEGACYTH` to switch between the old and new APIs (I was lazy :grin: and don't have the older version to test here).  Also, I'm not sure if it's worth the cost of maintaining that.

Feel free to exclude any (or all) of the changes.
